### PR TITLE
Release trunk as 1.1 and switch to 2.0.0-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.iml
 target/*
+/.settings
+/target
+/.classpath
+/.project

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>sonia.scm.plugins</groupId>
         <artifactId>scm-plugins</artifactId>
-        <version>1.30</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <groupId>sonia.scm.plugins</groupId>
     <artifactId>scm-bamboo-plugin</artifactId>
-    <version>1.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>smp</packaging>
     <name>scm-bamboo-plugin</name>
     <url>https://github.com/soudmaijer/scm-bamboo-plugin</url>
     <description>This plugin will ping your Bamboo CI server when a new commit is pushed to SCM-Manager.</description>

--- a/src/main/java/sonia/scm/bamboo/BambooHook.java
+++ b/src/main/java/sonia/scm/bamboo/BambooHook.java
@@ -34,23 +34,24 @@ package sonia.scm.bamboo;
 
 //~--- non-JDK imports --------------------------------------------------------
 
-import com.google.inject.Inject;
-import com.google.inject.Provider;
+import java.io.IOException;
+
+import javax.inject.Singleton;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import sonia.scm.net.HttpClient;
 import sonia.scm.net.HttpRequest;
 import sonia.scm.net.HttpResponse;
-import sonia.scm.plugin.ext.Extension;
+import sonia.scm.plugin.Extension;
+import sonia.scm.repository.PostReceiveRepositoryHookEvent;
 import sonia.scm.repository.Repository;
-import sonia.scm.repository.RepositoryHook;
-import sonia.scm.repository.RepositoryHookEvent;
-import sonia.scm.repository.RepositoryHookType;
 import sonia.scm.util.Util;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
+import com.github.legman.Subscribe;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 //~--- JDK imports ------------------------------------------------------------
 
@@ -58,7 +59,8 @@ import java.util.Collection;
  * @author Stephan Oudmaijer
  */
 @Extension
-public class BambooHook implements RepositoryHook {
+@Singleton
+public class BambooHook {
 
     /**
      * Field description
@@ -89,6 +91,9 @@ public class BambooHook implements RepositoryHook {
      */
     @Inject
     public BambooHook(final Provider<HttpClient> httpClientProvider, final BambooPluginConfigRepository bambooPluginConfigRepository) {
+    	
+    	logger.info("bamboo hook initialized");
+    	
         this.httpClientProvider = httpClientProvider;
         this.bambooPluginConfigRepository = bambooPluginConfigRepository;
     }
@@ -98,37 +103,17 @@ public class BambooHook implements RepositoryHook {
     /**
      * {@inheritDoc}
      */
-    @Override
-    public void onEvent(RepositoryHookEvent event) {
+    @Subscribe
+    public void onEvent(PostReceiveRepositoryHookEvent event) {
         Repository repository = event.getRepository();
 
+        logger.info("event fired on repository: " + repository);
+        
         if (repository != null) {
             handleRepositoryEvent(repository);
         } else if (logger.isWarnEnabled()) {
             logger.warn("receive repository hook without repository");
         }
-    }
-
-    //~--- get methods ----------------------------------------------------------
-
-    /**
-     * POST_RECEIVE
-     *
-     * @return POST_RECEIVE repository hook type.
-     */
-    @Override
-    public Collection<RepositoryHookType> getTypes() {
-        return Arrays.asList(RepositoryHookType.POST_RECEIVE);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return true
-     */
-    @Override
-    public boolean isAsync() {
-        return true;
     }
 
     //~--- methods --------------------------------------------------------------

--- a/src/main/resources/sonia/scm/version/scm-bamboo-plugin
+++ b/src/main/resources/sonia/scm/version/scm-bamboo-plugin
@@ -1,0 +1,1 @@
+scm-bamboo-plugin/${project.version}

--- a/src/test/java/sonia/scm/bamboo/BambooHookTest.java
+++ b/src/test/java/sonia/scm/bamboo/BambooHookTest.java
@@ -1,6 +1,13 @@
 package sonia.scm.bamboo;
 
-import com.google.inject.Provider;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,18 +15,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import sonia.scm.net.HttpClient;
 import sonia.scm.net.HttpRequest;
+import sonia.scm.repository.PostReceiveRepositoryHookEvent;
 import sonia.scm.repository.Repository;
-import sonia.scm.repository.RepositoryHookEvent;
 
-import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.google.inject.Provider;
 
 /**
  * Test class for the BambooHook.
@@ -52,7 +54,7 @@ public class BambooHookTest {
 
     @Test
     public void testTriggerBamboo() throws IOException {
-        RepositoryHookEvent rhe = Mockito.mock(RepositoryHookEvent.class);
+    	PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(null);
         Repository repo = Mockito.mock(Repository.class);
 
         when(rhe.getRepository()).thenReturn(repo);
@@ -75,7 +77,7 @@ public class BambooHookTest {
 
     @Test
     public void testTriggerBambooWithAuthentication() throws IOException {
-        RepositoryHookEvent rhe = Mockito.mock(RepositoryHookEvent.class);
+    	PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(null);
         Repository repo = Mockito.mock(Repository.class);
 
         when(rhe.getRepository()).thenReturn(repo);
@@ -100,7 +102,7 @@ public class BambooHookTest {
 
     @Test
     public void testTriggerBambooWithOverrideUrl() throws IOException {
-        RepositoryHookEvent rhe = Mockito.mock(RepositoryHookEvent.class);
+    	PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(null);
         Repository repo = Mockito.mock(Repository.class);
 
         when(rhe.getRepository()).thenReturn(repo);

--- a/src/test/java/sonia/scm/bamboo/BambooHookTest.java
+++ b/src/test/java/sonia/scm/bamboo/BambooHookTest.java
@@ -61,7 +61,6 @@ public class BambooHookTest {
     	RepositoryHookEvent event = new RepositoryHookEvent(null, repo, RepositoryHookType.POST_RECEIVE);
 		PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(event);
 
-//        when(rhe.getRepository()).thenReturn(repo);
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_URL)).thenReturn(null);
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_PLANS)).thenReturn("A,B");
 

--- a/src/test/java/sonia/scm/bamboo/BambooHookTest.java
+++ b/src/test/java/sonia/scm/bamboo/BambooHookTest.java
@@ -20,6 +20,8 @@ import sonia.scm.net.HttpClient;
 import sonia.scm.net.HttpRequest;
 import sonia.scm.repository.PostReceiveRepositoryHookEvent;
 import sonia.scm.repository.Repository;
+import sonia.scm.repository.RepositoryHookEvent;
+import sonia.scm.repository.RepositoryHookType;
 
 import com.google.inject.Provider;
 
@@ -54,10 +56,12 @@ public class BambooHookTest {
 
     @Test
     public void testTriggerBamboo() throws IOException {
-    	PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(null);
-        Repository repo = Mockito.mock(Repository.class);
+    	Repository repo = Mockito.mock(Repository.class);
+    	
+    	RepositoryHookEvent event = new RepositoryHookEvent(null, repo, RepositoryHookType.POST_RECEIVE);
+		PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(event);
 
-        when(rhe.getRepository()).thenReturn(repo);
+//        when(rhe.getRepository()).thenReturn(repo);
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_URL)).thenReturn(null);
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_PLANS)).thenReturn("A,B");
 
@@ -77,10 +81,11 @@ public class BambooHookTest {
 
     @Test
     public void testTriggerBambooWithAuthentication() throws IOException {
-    	PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(null);
         Repository repo = Mockito.mock(Repository.class);
-
-        when(rhe.getRepository()).thenReturn(repo);
+        
+    	RepositoryHookEvent event = new RepositoryHookEvent(null, repo, RepositoryHookType.POST_RECEIVE);
+		PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(event);
+        
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_URL)).thenReturn(null);
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_PLANS)).thenReturn("A,B");
 
@@ -102,10 +107,11 @@ public class BambooHookTest {
 
     @Test
     public void testTriggerBambooWithOverrideUrl() throws IOException {
-    	PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(null);
         Repository repo = Mockito.mock(Repository.class);
+        
+    	RepositoryHookEvent event = new RepositoryHookEvent(null, repo, RepositoryHookType.POST_RECEIVE);
+		PostReceiveRepositoryHookEvent rhe = new PostReceiveRepositoryHookEvent(event);
 
-        when(rhe.getRepository()).thenReturn(repo);
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_URL)).thenReturn("http://override");
         when(repo.getProperty(BambooHook.PROPERTY_BAMBOO_PLANS)).thenReturn("A,B");
 


### PR DESCRIPTION
Recommend releasing current trunk to 1.1 and switch development version to 2.0.0-SNAPSHOT to become compatible with  [scm-manager](https://bitbucket.org/sdorra/scm-manager/src) trunk.
